### PR TITLE
Patch api trips tripid

### DIFF
--- a/api/__tests__/app.test.js
+++ b/api/__tests__/app.test.js
@@ -25,7 +25,7 @@ describe("Express App", () => {
   });
 
   describe("GET /api", () => {
-    it("200: Returns an object with keys describing the different endpoints", () => {
+    it.only("200: Returns an object with keys describing the different endpoints", () => {
       return request(app)
         .get("/api")
         .expect(200)
@@ -38,6 +38,7 @@ describe("Express App", () => {
               "DELETE /api/trips/:trip_id": expect.any(Object),
               "GET /api/users": expect.any(Object),
               "GET /api/users/:username": expect.any(Object),
+              "PATCH /api/trips/:trip_id": expect.any(Object),
             })
           );
         });

--- a/api/__tests__/app.test.js
+++ b/api/__tests__/app.test.js
@@ -37,7 +37,7 @@ describe("Express App", () => {
               "GET /api/trips/:trip_id": expect.any(Object),
               "DELETE /api/trips/:trip_id": expect.any(Object),
               "GET /api/users": expect.any(Object),
-              "GET /api/users/:username":expect.any(Object)
+              "GET /api/users/:username": expect.any(Object),
             })
           );
         });

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -980,53 +980,53 @@ describe("Trips", () => {
         );
       });
     });
-    // describe("Budget Errors", () => {
-    //   it("400: Returns 'budget is not type 'number'.' for a budget that is the wrong type", () => {
-    //     let trip_id;
-    //     const changeTripData = {
-    //       budget: "hello",
-    //     };
-    //     return (
-    //       request(app)
-    //         // Will Clegg created the trip (first user listed in attending)
-    //         .get("/api/trips?username=willclegg")
-    //         .then(({ body: { trips } }) => {
-    //           trip_id = trips[0]._id;
-    //         })
-    //         .then(() => {
-    //           return request(app)
-    //             .patch(`/api/trips/${trip_id}?username=willclegg`)
-    //             .send(changeTripData)
-    //             .expect(400)
-    //             .then(({ body: { msg } }) => {
-    //               expect(msg).toBe("budget is not type 'number'.");
-    //             });
-    //         })
-    //     );
-    //   });
-    //   it("400: Returns 'Budget cannot be £0 or less.' when the user tries to change the budget to be 0 or lower", () => {
-    //     let trip_id;
-    //     const changeTripData = {
-    //       budget: -1000,
-    //     };
-    //     return (
-    //       request(app)
-    //         // Will Clegg created the trip (first user listed in attending)
-    //         .get("/api/trips?username=willclegg")
-    //         .then(({ body: { trips } }) => {
-    //           trip_id = trips[0]._id;
-    //         })
-    //         .then(() => {
-    //           return request(app)
-    //             .patch(`/api/trips/${trip_id}?username=willclegg`)
-    //             .send(changeTripData)
-    //             .expect(400)
-    //             .then(({ body: { msg } }) => {
-    //               expect(msg).toBe("Budget cannot be £0 or less.");
-    //             });
-    //         })
-    //     );
-    //   });
-    // });
+    describe("Budget Errors", () => {
+      it("400: Returns 'budgetGBP is not type 'number'.' for a budget that is the wrong type", () => {
+        let trip_id;
+        const changeTripData = {
+          budgetGBP: "hello",
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("budgetGBP is not type 'number'.");
+                });
+            })
+        );
+      });
+      it("400: Returns 'Budget cannot be £0 or less.' when the user tries to change the budget to be 0 or lower", () => {
+        let trip_id;
+        const changeTripData = {
+          budgetGBP: -1000,
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("Budget cannot be £0 or less.");
+                });
+            })
+        );
+      });
+    });
   });
 });

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -815,6 +815,28 @@ describe("Trips", () => {
             });
         });
     });
+    it("200: Returns an object containing the updated and shortened trip and sets any days that are no longer included in the trip to dayNumber: NaN", () => {
+      let trip_id;
+      const changeTripData = {
+        tripName: "Prague Hols",
+        endDate: new Date(2022, 8, 2),
+      };
+      return request(app)
+        .get("/api/trips?username=willclegg")
+        .then(({ body: { trips } }) => {
+          trip_id = trips[2]._id;
+        })
+        .then(() => {
+          return request(app)
+            .patch(`/api/trips/${trip_id}?username=willclegg`)
+            .send(changeTripData)
+            .expect(200)
+            .then(({ body }) => {
+              expect(body.trip.tripName).toBe("Prague Hols");
+              expect(body.trip.days[2].dayNumber).toBe(0);
+            });
+        });
+    });
     describe("General Errors", () => {
       it("401: Returns {msg: You are unauthorised to change this trip.} when a user not listed as attending attempts to change the trip", () => {
         let trip_id;

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -927,33 +927,33 @@ describe("Trips", () => {
           });
       });
     });
-    // describe("Trip ID Errors", () => {
-    //   const changeTripData = {
-    //     tripName: "Greece Takeover!",
-    //   };
-    //   it("400: Returns {msg: trip_id 'X' is an invalid trip ID.} when a user tries to access a trip id with the wrong format.", () => {
-    //     return request(app)
-    //       .patch(`/api/trips/234?username=alexrong`)
-    //       .send(changeTripData)
-    //       .expect(400)
-    //       .then(({ body: { msg } }) => {
-    //         expect(msg).toBe("trip_id '234' is an invalid trip ID.");
-    //       });
-    //   });
-    //   it("404: Returns {msg: trip_id 'X' does not exist.} when trip cannot be found", () => {
-    //     const changeTripData = {
-    //       tripName: "Greece Takeover!",
-    //     };
-    //     return request(app)
-    //       .get("/api/trips/507f1f77bcf86cd799439011?username=willclegg")
-    //       .send(changeTripData)
-    //       .expect(404)
-    //       .then(({ body: { msg } }) => {
-    //         expect(msg).toBe(
-    //           "trip_id '507f1f77bcf86cd799439011' does not exist."
-    //         );
-    //       });
-    //   });
-    // });
+    describe("Trip ID Errors", () => {
+      it("400: Returns {msg: trip_id 'X' is an invalid trip ID.} when a user tries to access a trip id with the wrong format.", () => {
+        const changeTripData = {
+          tripName: "Greece Takeover!",
+        };
+        return request(app)
+          .patch(`/api/trips/234?username=alexrong`)
+          .send(changeTripData)
+          .expect(400)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe("trip_id '234' is an invalid trip ID.");
+          });
+      });
+      it("404: Returns {msg: trip_id 'X' does not exist.} when trip cannot be found", () => {
+        const changeTripData = {
+          tripName: "Greece Takeover!",
+        };
+        return request(app)
+          .patch("/api/trips/507f1f77bcf86cd799439011?username=willclegg")
+          .send(changeTripData)
+          .expect(404)
+          .then(({ body: { msg } }) => {
+            expect(msg).toBe(
+              "trip_id '507f1f77bcf86cd799439011' does not exist."
+            );
+          });
+      });
+    });
   });
 });

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -606,7 +606,7 @@ describe("Trips", () => {
         });
     });
   });
-  describe("PATCH /api/trips/:trip_id?username=X", () => {
+  describe.only("PATCH /api/trips/:trip_id?username=X", () => {
     it("200: Returns an object containing the updated trip on a key of trip where details are changed and a person is added to the trip", () => {
       let trip_id;
       const changeTripData = {
@@ -840,7 +840,7 @@ describe("Trips", () => {
             })
         );
       });
-      it.only("400: Returns {msg: Cannot update field 'country'.} when the user tries to update the country field (a field they cannot update).", () => {
+      it("400: Returns {msg: Cannot update field 'country'.} when the user tries to update the country field (a field they cannot update).", () => {
         let trip_id;
         const changeTripData = {
           tripName: "Turkey Takeover",
@@ -865,5 +865,95 @@ describe("Trips", () => {
         );
       });
     });
+    describe("Username Errors", () => {
+      it("400: Returns {msg: Username Not Specified} when no username query", () => {
+        const changeTripData = {
+          tripName: "Greece Takeover!",
+        };
+        return request(app)
+          .get("/api/trips?username=willclegg")
+          .then(({ body: { trips } }) => {
+            const trip_id = trips[0]._id;
+            return trip_id;
+          })
+          .then((trip_id) => {
+            return request(app)
+              .patch(`/api/trips/${trip_id}`)
+              .send(changeTripData)
+              .expect(400)
+              .then(({ body: { msg } }) => {
+                expect(msg).toBe("Username Not Specified");
+              });
+          });
+      });
+      it("400: Returns {msg: User 'X' is an invalid username.} for invalid username query", () => {
+        const changeTripData = {
+          tripName: "Greece Takeover!",
+        };
+        return request(app)
+          .get("/api/trips?username=willclegg")
+          .then(({ body: { trips } }) => {
+            const trip_id = trips[0]._id;
+            return trip_id;
+          })
+          .then((trip_id) => {
+            return request(app)
+              .patch(`/api/trips/${trip_id}?username=23`)
+              .send(changeTripData)
+              .expect(400)
+              .then(({ body: { msg } }) => {
+                expect(msg).toBe("User '23' is an invalid username.");
+              });
+          });
+      });
+      it("404: Returns {msg: User 'jimstevenson' does not exist.} when username cannot be found", () => {
+        const changeTripData = {
+          tripName: "Greece Takeover!",
+        };
+        return request(app)
+          .get("/api/trips?username=willclegg")
+          .then(({ body: { trips } }) => {
+            const trip_id = trips[0]._id;
+            return trip_id;
+          })
+          .then((trip_id) => {
+            return request(app)
+              .patch(`/api/trips/${trip_id}?username=jimstevenson`)
+              .send(changeTripData)
+              .expect(404)
+              .then(({ body: { msg } }) => {
+                expect(msg).toBe("User 'jimstevenson' does not exist.");
+              });
+          });
+      });
+    });
+    // describe("Trip ID Errors", () => {
+    //   const changeTripData = {
+    //     tripName: "Greece Takeover!",
+    //   };
+    //   it("400: Returns {msg: trip_id 'X' is an invalid trip ID.} when a user tries to access a trip id with the wrong format.", () => {
+    //     return request(app)
+    //       .patch(`/api/trips/234?username=alexrong`)
+    //       .send(changeTripData)
+    //       .expect(400)
+    //       .then(({ body: { msg } }) => {
+    //         expect(msg).toBe("trip_id '234' is an invalid trip ID.");
+    //       });
+    //   });
+    //   it("404: Returns {msg: trip_id 'X' does not exist.} when trip cannot be found", () => {
+    //     const changeTripData = {
+    //       tripName: "Greece Takeover!",
+    //     };
+    //     return request(app)
+    //       .get("/api/trips/507f1f77bcf86cd799439011?username=willclegg")
+    //       .send(changeTripData)
+    //       .expect(404)
+    //       .then(({ body: { msg } }) => {
+    //         expect(msg).toBe(
+    //           "trip_id '507f1f77bcf86cd799439011' does not exist."
+    //         );
+    //       });
+    //   });
+    // });
   });
 });

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -606,4 +606,142 @@ describe("Trips", () => {
         });
     });
   });
+  describe("PATCH /api/trips/:trip_id?username=X", () => {
+    it.only("200: Returns an object containing the updated trip on a key of trip where details are changed and a person is added to the trip", () => {
+      let trip_id;
+      const changeTripData = {
+        tripName: "Wedding in Greece",
+        addPeople: ["mohamedelrofai"],
+        startDate: new Date(2023, 6, 10),
+        endDate: new Date(2023, 6, 16),
+        budgetGBP: 1200,
+        accommodation: {
+          accommodationName: "Hilton",
+          latitude: 37.9756481,
+          longitude: 23.751097,
+          address: {
+            parking: "Hilton",
+            road: "Βασιλίσσης Σοφίας",
+            suburb: "Kolonaki",
+            city_district: "1st District of Athens",
+            city: "Athens",
+            municipality: "Municipality of Athens",
+            county: "Regional Unit of Central Athens",
+            state_district: "Attica",
+            state: "Attica",
+            postcode: "11528",
+            country: "Greece",
+            country_code: "gr",
+          },
+        },
+      };
+      return request(app)
+        .get("/api/trips?username=willclegg")
+        .then(({ body: { trips } }) => {
+          trip_id = trips[0]._id;
+        })
+        .then(() => {
+          return request(app)
+            .patch(`/api/trips/${trip_id}?username=willclegg`)
+            .send(changeTripData)
+            .expect(200)
+            .then(({ body }) => {
+              body.trip._id = new ObjectId(body.trip._id);
+              expect(body.trip).toEqual({
+                _id: new ObjectId(trip_id),
+                tripName: "Wedding in Greece",
+                attending: ["willclegg", "mohamedelrofai"],
+                startDate: "2023-07-09T23:00:00.000Z",
+                endDate: "2023-07-15T23:00:00.000Z",
+                budgetGBP: 1200,
+                country: "Greece",
+                accommodation: {
+                  accommodationName: "Hilton",
+                  latitude: 37.9756481,
+                  longitude: 23.751097,
+                  address: {
+                    parking: "Hilton",
+                    road: "Βασιλίσσης Σοφίας",
+                    suburb: "Kolonaki",
+                    city_district: "1st District of Athens",
+                    city: "Athens",
+                    municipality: "Municipality of Athens",
+                    county: "Regional Unit of Central Athens",
+                    state_district: "Attica",
+                    state: "Attica",
+                    postcode: "11528",
+                    country: "Greece",
+                    country_code: "gr",
+                  },
+                },
+                days: [
+                  {
+                    _id: expect.any(String),
+                    dayNumber: 1,
+                    activities: [
+                      {
+                        _id: expect.any(String),
+                        activityName: "Mykonos Dive Center",
+                        latitude: 37.41,
+                        longitude: 25.356,
+                        address: {
+                          name: "Mykonos Dive Center",
+                          road: "f",
+                          city: "Plintri",
+                          state: "Aegean",
+                          postcode: "84600",
+                          country: "Greece",
+                          country_code: "GR",
+                        },
+                        type: "sport",
+                      },
+                    ],
+                  },
+                  {
+                    _id: expect.any(String),
+                    dayNumber: 2,
+                    activities: [
+                      {
+                        _id: expect.any(String),
+                        activityName: "Jackie O' Beach Club",
+                        latitude: 37.414,
+                        longitude: 25.367,
+                        address: {
+                          address:
+                            "Jackie O' Beach Club, Μύκονος 84600, Greece",
+                        },
+                        type: "bar",
+                      },
+                    ],
+                  },
+                ],
+              });
+            });
+        });
+    });
+    it("200: Returns an object containing the updated trip where a person has been removed from the trip", () => {
+      let trip_id;
+      const changeTripData = {
+        removePeople: ["jesskemp"],
+      };
+      return request(app)
+        .get("/api/trips?username=willclegg")
+        .then(({ body: { trips } }) => {
+          trip_id = trips[2]._id;
+        })
+        .then(() => {
+          return request(app)
+            .patch(`/api/trips/${trip_id}?username=willclegg`)
+            .send(changeTripData)
+            .expect(200)
+            .then(({ body }) => {
+              expect(body.attending).toEqual([
+                "willclegg",
+                "alexrong",
+                "mohammedelrofai",
+              ]);
+            });
+        });
+    });
+  });
 });

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -646,6 +646,7 @@ describe("Trips", () => {
             .send(changeTripData)
             .expect(200)
             .then(({ body }) => {
+              console.log(body);
               body.trip._id = new ObjectId(body.trip._id);
               expect(body.trip).toEqual({
                 _id: new ObjectId(trip_id),
@@ -1492,6 +1493,151 @@ describe("Trips", () => {
                 .expect(400)
                 .then(({ body: { msg } }) => {
                   expect(msg).toBe("Your trip must have a creator.");
+                });
+            })
+        );
+      });
+    });
+    describe("Start Date Errors", () => {
+      it("400: Returns 'startDate is not type 'date'.' for a startDate that is the wrong type", () => {
+        let trip_id;
+        const changeTripData = {
+          startDate: "hey",
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("startDate is not type 'date'.");
+                });
+            })
+        );
+      });
+      it("400: Returns 'startDate cannot be in the past.' for a startDate that is in the past", () => {
+        let trip_id;
+        const changeTripData = {
+          startDate: new Date(2019, 2, 12),
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("startDate cannot be in the past.");
+                });
+            })
+        );
+      });
+      it("400: Returns 'startDate cannot be moved to after the endDate.' if given a startDate which is after the current endDate", () => {
+        let trip_id;
+        const changeTripData = {
+          startDate: new Date(2024, 5, 10),
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe(
+                    "startDate cannot be moved to after the endDate."
+                  );
+                });
+            })
+        );
+      });
+    });
+    describe("End Date Errors", () => {
+      it("400: Returns 'endDate is not type 'date'.' for a endDate that is the wrong type", () => {
+        let trip_id;
+        const changeTripData = {
+          endDate: 26835,
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("endDate is not type 'date'.");
+                });
+            })
+        );
+      });
+      it("400: Returns 'endDate cannot be before startDate.' if given an endDate which is before the current startDate", () => {
+        let trip_id;
+        const changeTripData = {
+          endDate: new Date(2019, 2, 12),
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("endDate cannot be before startDate.");
+                });
+            })
+        );
+      });
+      it("400: Returns 'endDate cannot be before startDate.' if given an endDate which is before the new startDate", () => {
+        let trip_id;
+        const changeTripData = {
+          endDate: new Date(2023, 2, 12),
+          startDate: new Date(2023, 3, 2),
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("endDate cannot be before startDate.");
                 });
             })
         );

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -606,8 +606,8 @@ describe("Trips", () => {
         });
     });
   });
-  describe("PATCH /api/trips/:trip_id?username=X", () => {
-    it.only("200: Returns an object containing the updated trip on a key of trip where details are changed and a person is added to the trip", () => {
+  describe.only("PATCH /api/trips/:trip_id?username=X", () => {
+    it("200: Returns an object containing the updated trip on a key of trip where details are changed and a person is added to the trip", () => {
       let trip_id;
       const changeTripData = {
         tripName: "Wedding in Greece",
@@ -719,29 +719,79 @@ describe("Trips", () => {
             });
         });
     });
-    // it("200: Returns an object containing the updated trip where a person has been removed from the trip", () => {
-    //   let trip_id;
-    //   const changeTripData = {
-    //     removePeople: ["jesskemp"],
-    //   };
-    //   return request(app)
-    //     .get("/api/trips?username=willclegg")
-    //     .then(({ body: { trips } }) => {
-    //       trip_id = trips[2]._id;
-    //     })
-    //     .then(() => {
-    //       return request(app)
-    //         .patch(`/api/trips/${trip_id}?username=willclegg`)
-    //         .send(changeTripData)
-    //         .expect(200)
-    //         .then(({ body }) => {
-    //           expect(body.attending).toEqual([
-    //             "willclegg",
-    //             "alexrong",
-    //             "mohammedelrofai",
-    //           ]);
-    //         });
-    //     });
-    // });
+    it("200: Returns an object containing the updated trip where a person has been removed from the trip", () => {
+      let trip_id;
+      const changeTripData = {
+        removePeople: ["jesskemp"],
+      };
+      return request(app)
+        .get("/api/trips?username=willclegg")
+        .then(({ body: { trips } }) => {
+          trip_id = trips[2]._id;
+        })
+        .then(() => {
+          return request(app)
+            .patch(`/api/trips/${trip_id}?username=willclegg`)
+            .send(changeTripData)
+            .expect(200)
+            .then(({ body }) => {
+              expect(body.trip.attending).toEqual([
+                "willclegg",
+                "alexrong",
+                "mohamedelrofai",
+              ]);
+            });
+        });
+    });
+    it("200: Returns an object containing the updated trip where a new creator has been assigned", () => {
+      let trip_id;
+      const changeTripData = {
+        newCreator: "jesskemp",
+      };
+      return request(app)
+        .get("/api/trips?username=willclegg")
+        .then(({ body: { trips } }) => {
+          trip_id = trips[2]._id;
+        })
+        .then(() => {
+          return request(app)
+            .patch(`/api/trips/${trip_id}?username=willclegg`)
+            .send(changeTripData)
+            .expect(200)
+            .then(({ body }) => {
+              expect(body.trip.attending).toEqual([
+                "jesskemp",
+                "willclegg",
+                "alexrong",
+                "mohamedelrofai",
+              ]);
+            });
+        });
+    });
+    it("200: Returns an object containing the updated trip when the creator has added people to the trip and assigned a new creator at the same time", () => {
+      let trip_id;
+      const changeTripData = {
+        addPeople: ["jesskemp", "alexrong"],
+        newCreator: "jesskemp",
+      };
+      return request(app)
+        .get("/api/trips?username=willclegg")
+        .then(({ body: { trips } }) => {
+          trip_id = trips[0]._id;
+        })
+        .then(() => {
+          return request(app)
+            .patch(`/api/trips/${trip_id}?username=willclegg`)
+            .send(changeTripData)
+            .expect(200)
+            .then(({ body }) => {
+              expect(body.trip.attending).toEqual([
+                "jesskemp",
+                "willclegg",
+                "alexrong",
+              ]);
+            });
+        });
+    });
   });
 });

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -1028,5 +1028,142 @@ describe("Trips", () => {
         );
       });
     });
+    describe("Accommodation Errors", () => {
+      it("400: Returns 'accommodation is not type 'object'.' for an accommodation that is the wrong type", () => {
+        let trip_id;
+        const changeTripData = {
+          accommodation: ["hey"],
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("accommodation is not type 'object'.");
+                });
+            })
+        );
+      });
+      it("400: Returns 'accommodationName is not type 'string'.' for an accommodation name that is the wrong type", () => {
+        let trip_id;
+        const changeTripData = {
+          accommodation: {
+            accommodationName: 268,
+            latitude: 36.2648311,
+            longitude: 29.409945,
+            address: {},
+          },
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("accommodationName is not type 'string'.");
+                });
+            })
+        );
+      });
+      it("400: Returns 'latitude is not type 'number'.' for an latitude that is the wrong type", () => {
+        let trip_id;
+        const changeTripData = {
+          accommodation: {
+            accommodationName: "Hilton Hotel",
+            latitude: "here",
+            longitude: 29.409945,
+            address: {},
+          },
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("latitude is not type 'number'.");
+                });
+            })
+        );
+      });
+      it("400: Returns 'longitude is not type 'number'.' for an longitude that is the wrong type", () => {
+        let trip_id;
+        const changeTripData = {
+          accommodation: {
+            accommodationName: "Hilton Hotel",
+            latitude: 29.409945,
+            longitude: [],
+            address: {},
+          },
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("longitude is not type 'number'.");
+                });
+            })
+        );
+      });
+      it("400: Returns 'address is not type 'object'.' for an address that is the wrong type", () => {
+        let trip_id;
+        const changeTripData = {
+          accommodation: {
+            accommodationName: "Hilton Hotel",
+            latitude: 29.409945,
+            longitude: 36.2648311,
+            address: true,
+          },
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("address is not type 'object'.");
+                });
+            })
+        );
+      });
+    });
   });
 });

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -1165,5 +1165,122 @@ describe("Trips", () => {
         );
       });
     });
+    describe("Add People Errors", () => {
+      it("400: Returns 'addPeople is not type 'array'.' for an addPeople request that is the wrong type", () => {
+        let trip_id;
+        const changeTripData = {
+          addPeople: 256,
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("addPeople is not type 'array'.");
+                });
+            })
+        );
+      });
+      it("400: Returns {msg: addPeople requires one or more usernames.} when no username are given in the array", () => {
+        let trip_id;
+        const changeTripData = {
+          addPeople: [],
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("addPeople requires one or more usernames.");
+                });
+            })
+        );
+      });
+      it("400: Returns {msg: User 'X' is an invalid username.} for invalid username query", () => {
+        let trip_id;
+        const changeTripData = {
+          addPeople: [234],
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("User '234' is an invalid username.");
+                });
+            })
+        );
+      });
+      it("404: Returns {msg: User 'jimstevenson' does not exist.} when username cannot be found", () => {
+        let trip_id;
+        const changeTripData = {
+          addPeople: ["jimstevenson"],
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(404)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("User 'jimstevenson' does not exist.");
+                });
+            })
+        );
+      });
+      it.only("400: Returns {msg: User 'jesskemp' is already attending.} when username cannot be found", () => {
+        let trip_id;
+        const changeTripData = {
+          addPeople: ["jesskemp"],
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[2]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("User 'jesskemp' is already attending.");
+                });
+            })
+        );
+      });
+    });
   });
 });

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -719,29 +719,29 @@ describe("Trips", () => {
             });
         });
     });
-    it("200: Returns an object containing the updated trip where a person has been removed from the trip", () => {
-      let trip_id;
-      const changeTripData = {
-        removePeople: ["jesskemp"],
-      };
-      return request(app)
-        .get("/api/trips?username=willclegg")
-        .then(({ body: { trips } }) => {
-          trip_id = trips[2]._id;
-        })
-        .then(() => {
-          return request(app)
-            .patch(`/api/trips/${trip_id}?username=willclegg`)
-            .send(changeTripData)
-            .expect(200)
-            .then(({ body }) => {
-              expect(body.attending).toEqual([
-                "willclegg",
-                "alexrong",
-                "mohammedelrofai",
-              ]);
-            });
-        });
-    });
+    // it("200: Returns an object containing the updated trip where a person has been removed from the trip", () => {
+    //   let trip_id;
+    //   const changeTripData = {
+    //     removePeople: ["jesskemp"],
+    //   };
+    //   return request(app)
+    //     .get("/api/trips?username=willclegg")
+    //     .then(({ body: { trips } }) => {
+    //       trip_id = trips[2]._id;
+    //     })
+    //     .then(() => {
+    //       return request(app)
+    //         .patch(`/api/trips/${trip_id}?username=willclegg`)
+    //         .send(changeTripData)
+    //         .expect(200)
+    //         .then(({ body }) => {
+    //           expect(body.attending).toEqual([
+    //             "willclegg",
+    //             "alexrong",
+    //             "mohammedelrofai",
+    //           ]);
+    //         });
+    //     });
+    // });
   });
 });

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -606,7 +606,7 @@ describe("Trips", () => {
         });
     });
   });
-  describe.only("PATCH /api/trips/:trip_id?username=X", () => {
+  describe("PATCH /api/trips/:trip_id?username=X", () => {
     it("200: Returns an object containing the updated trip on a key of trip where details are changed and a person is added to the trip", () => {
       let trip_id;
       const changeTripData = {
@@ -955,5 +955,78 @@ describe("Trips", () => {
           });
       });
     });
+    describe("Trip Name Errors", () => {
+      it("400: Returns 'tripName is not type 'string'.' for a tripName that is the wrong type", () => {
+        let trip_id;
+        const changeTripData = {
+          tripName: 23,
+        };
+        return (
+          request(app)
+            // Will Clegg created the trip (first user listed in attending)
+            .get("/api/trips?username=willclegg")
+            .then(({ body: { trips } }) => {
+              trip_id = trips[0]._id;
+            })
+            .then(() => {
+              return request(app)
+                .patch(`/api/trips/${trip_id}?username=willclegg`)
+                .send(changeTripData)
+                .expect(400)
+                .then(({ body: { msg } }) => {
+                  expect(msg).toBe("tripName is not type 'string'.");
+                });
+            })
+        );
+      });
+    });
+    // describe("Budget Errors", () => {
+    //   it("400: Returns 'budget is not type 'number'.' for a budget that is the wrong type", () => {
+    //     let trip_id;
+    //     const changeTripData = {
+    //       budget: "hello",
+    //     };
+    //     return (
+    //       request(app)
+    //         // Will Clegg created the trip (first user listed in attending)
+    //         .get("/api/trips?username=willclegg")
+    //         .then(({ body: { trips } }) => {
+    //           trip_id = trips[0]._id;
+    //         })
+    //         .then(() => {
+    //           return request(app)
+    //             .patch(`/api/trips/${trip_id}?username=willclegg`)
+    //             .send(changeTripData)
+    //             .expect(400)
+    //             .then(({ body: { msg } }) => {
+    //               expect(msg).toBe("budget is not type 'number'.");
+    //             });
+    //         })
+    //     );
+    //   });
+    //   it("400: Returns 'Budget cannot be £0 or less.' when the user tries to change the budget to be 0 or lower", () => {
+    //     let trip_id;
+    //     const changeTripData = {
+    //       budget: -1000,
+    //     };
+    //     return (
+    //       request(app)
+    //         // Will Clegg created the trip (first user listed in attending)
+    //         .get("/api/trips?username=willclegg")
+    //         .then(({ body: { trips } }) => {
+    //           trip_id = trips[0]._id;
+    //         })
+    //         .then(() => {
+    //           return request(app)
+    //             .patch(`/api/trips/${trip_id}?username=willclegg`)
+    //             .send(changeTripData)
+    //             .expect(400)
+    //             .then(({ body: { msg } }) => {
+    //               expect(msg).toBe("Budget cannot be £0 or less.");
+    //             });
+    //         })
+    //     );
+    //   });
+    // });
   });
 });

--- a/api/__tests__/trips.test.js
+++ b/api/__tests__/trips.test.js
@@ -607,7 +607,7 @@ describe("Trips", () => {
     });
   });
   describe("PATCH /api/trips/:trip_id?username=X", () => {
-    it("200: Returns an object containing the updated trip on a key of trip where details are changed and a person is added to the trip", () => {
+    it.only("200: Returns an object containing the updated trip on a key of trip where details are changed and a person is added to the trip", () => {
       let trip_id;
       const changeTripData = {
         tripName: "Wedding in Greece",
@@ -1326,7 +1326,7 @@ describe("Trips", () => {
         );
       });
     });
-    describe("Remove People Erros", () => {
+    describe("Remove People Errors", () => {
       it("400: Returns 'removePeople is not type 'array'.' for a removePeople request that is the wrong type", () => {
         let trip_id;
         const changeTripData = {

--- a/api/__tests__/users.test.js
+++ b/api/__tests__/users.test.js
@@ -43,25 +43,36 @@ describe("Users", () => {
 
   describe("GET /api/users/:username", () => {
     it("200: /api/users/willclegg returns a valid user on a key of user", () => {
-      return request(app).get('/api/users/willclegg').expect(200).then(({body})=>{
-        expect(body.user).toEqual(expect.objectContaining({
-          _id:"willclegg",
-          firstName:"Will",
-          lastName:"Clegg"
-        }))
-      })
+      return request(app)
+        .get("/api/users/willclegg")
+        .expect(200)
+        .then(({ body }) => {
+          expect(body.user).toEqual(
+            expect.objectContaining({
+              _id: "willclegg",
+              firstName: "Will",
+              lastName: "Clegg",
+            })
+          );
+        });
     });
 
-    it("400: /api/users/123 returns 'User 123 is an invalid username'",()=>{
-      return request(app).get('/api/users/123').expect(400).then(({body})=>{
-        expect(body.msg).toBe("User '123' is an invalid username.")
-      })
-    })
+    it("400: /api/users/123 returns 'User 123 is an invalid username'", () => {
+      return request(app)
+        .get("/api/users/123")
+        .expect(400)
+        .then(({ body }) => {
+          expect(body.msg).toBe("User '123' is an invalid username.");
+        });
+    });
 
-    it("404: /api/users/NOTAUSER returns 'User NOTAUSER does not exist.'",()=>{
-      return request(app).get('/api/users/NOTAUSER').expect(404).then(({body})=>{
-        expect(body.msg).toBe("User 'NOTAUSER' does not exist.")
-      })
-    })
+    it("404: /api/users/NOTAUSER returns 'User NOTAUSER does not exist.'", () => {
+      return request(app)
+        .get("/api/users/NOTAUSER")
+        .expect(404)
+        .then(({ body }) => {
+          expect(body.msg).toBe("User 'NOTAUSER' does not exist.");
+        });
+    });
   });
 });

--- a/api/app.js
+++ b/api/app.js
@@ -7,6 +7,7 @@ const {
   addNewTrip,
   getSingleTrip,
   deleteTrip,
+  changeTrip,
 } = require("./controllers/trips.controllers");
 
 const app = express();
@@ -22,6 +23,8 @@ app.get("/api/trips", getTrips);
 app.get("/api/trips/:trip_id", getSingleTrip);
 
 app.post("/api/trips", addNewTrip);
+
+app.patch("/api/trips/:trip_id", changeTrip);
 
 app.delete("/api/trips/:trip_id", deleteTrip);
 

--- a/api/controllers/trips.controllers.js
+++ b/api/controllers/trips.controllers.js
@@ -3,6 +3,7 @@ const {
   postTrip,
   selectSingleTrip,
   removeTrip,
+  updateTrip,
 } = require("../models/trips.models");
 
 exports.getTrips = (req, res, next) => {
@@ -48,6 +49,20 @@ exports.deleteTrip = (req, res, next) => {
   removeTrip(trip_id, username)
     .then(() => {
       res.status(204).send({});
+    })
+    .catch((err) => {
+      next(err);
+    });
+};
+
+exports.changeTrip = (req, res, next) => {
+  const { trip_id } = req.params;
+  const { username } = req.query;
+  const newTripDetails = req.body;
+
+  updateTrip(trip_id, username, newTripDetails)
+    .then((trip) => {
+      res.status(200).send({ trip });
     })
     .catch((err) => {
       next(err);

--- a/api/controllers/users.controllers.js
+++ b/api/controllers/users.controllers.js
@@ -12,13 +12,14 @@ exports.getUsers = (req, res, next) => {
     });
 };
 
-exports.getUserByUsername = (req,res,next) => {
+exports.getUserByUsername = (req, res, next) => {
+  const { username } = req.params;
 
-  const {username}= req.params;
-
-  return selectUsername(username).then((user)=>{
-    res.status(200).send({user})
-  }).catch(err=>{
-    next(err)
-  })
+  return selectUsername(username)
+    .then((user) => {
+      res.status(200).send({ user });
+    })
+    .catch((err) => {
+      next(err);
+    });
 };

--- a/api/endpoints.json
+++ b/api/endpoints.json
@@ -187,5 +187,53 @@
     "parameters": ["username"],
     "exampleRequest": "/api/users/willclegg",
     "exampleResponse": {"user": { "_id": "willclegg", "firstName": "Will", "lastName": "Clegg" }}
+  },
+  "PATCH /api/trips/:trip_id": {
+    "description": "updates a trip in the database and returns the updated trip on a key of trip",
+    "required queries": ["username"],
+    "requestBodyDescription": "every option is the requestBody is optional but at least one field must be provided",
+    "requestBody": {
+      "tripName": "string",
+      "addPeople": "an array of all the new users to add",
+      "removePeople": "an array of all the users to remove from the trip",
+      "newCreator": "the username of the person to assign as creator of the trip (moved to index 0 in attending array)",
+      "budgetGBP": "integer > 0",
+      "startDate": "date (cannot be in the past)",
+      "endDate": "date (cannot be before the startDate)",
+      "accommodation": {
+        "accommodationName": "string",
+        "latitude": "number",
+        "longitude": "number",
+        "address": "empty object or object containing any number of address keys"
+      },
+      "exampleRequest": "/api/trips/:trip_id?username=willclegg",
+      "exampleResponse": {
+        "trip": {
+          "_id": "62f24229222c00589a5e617f",
+          "tripName": "Team 2 Trip Away",
+          "attending": ["jesskemp", "willclegg", "alexrong", "mohamedelrofai"],
+          "startDate": "2022-08-31T23:00:00.000Z",
+          "endDate": "2022-09-07T23:00:00.000Z",
+          "budgetGBP": 1700,
+          "country": "Czech Republic",
+          "accommodation": {
+            "accommodationName": "Hotel Pod Věží",
+            "latitude": 50.0873932,
+            "longitude": 14.4066676,
+            "address": {
+              "name": "Hotel Pod Věží",
+              "house_number": "2",
+              "road": "Mostecká",
+              "city": "Prague",
+              "state": "Prague",
+              "postcode": 11800,
+              "country": "Czechia",
+              "country_code": "CZ"
+            }
+          },
+          "days": []
+        }
+      }
+    }
   }
 }

--- a/api/models/trips.models.js
+++ b/api/models/trips.models.js
@@ -125,15 +125,18 @@ exports.updateTrip = (trip_id, username, newTripDetails) => {
     _id: new ObjectId(trip_id),
     attending: { $in: [username] },
   };
-  return checkFields(newTripDetails, [
-    "tripName",
-    "startDate",
-    "endDate",
-    "budgetGBP",
-    "accommodation",
-    "addPeople",
-    "removePeople",
-    "newCreator",
+  return Promise.all([
+    checkFields(newTripDetails, [
+      "tripName",
+      "startDate",
+      "endDate",
+      "budgetGBP",
+      "accommodation",
+      "addPeople",
+      "removePeople",
+      "newCreator",
+    ]),
+    selectUsername(username),
   ])
     .then(() => {
       return trips.findOne(query);

--- a/api/models/trips.models.js
+++ b/api/models/trips.models.js
@@ -124,16 +124,7 @@ exports.updateTrip = (trip_id, username, newTripDetails) => {
   return Promise.all([
     this.doesTripExist(trip_id),
     selectUsername(username),
-    checkFields(newTripDetails, [
-      "tripName",
-      "startDate",
-      "endDate",
-      "budgetGBP",
-      "accommodation",
-      "addPeople",
-      "removePeople",
-      "newCreator",
-    ]),
+    checkFields(newTripDetails),
   ])
     .then(() => {
       return trips.findOne({

--- a/api/models/trips.models.js
+++ b/api/models/trips.models.js
@@ -189,6 +189,38 @@ exports.updateTrip = (trip_id, username, newTripDetails) => {
           }
         }
       }
+      if (newTripDetails.newCreator) {
+        if (username !== trip.attending[0]) {
+          return Promise.reject({
+            status: 401,
+            msg: "You are not authorised to change the creator of this trip.",
+          });
+        }
+        if (trip.attending.includes(newTripDetails.newCreator) === false) {
+          if (
+            !newTripDetails.addPeople ||
+            newTripDetails.addPeople.includes(newTripDetails.newCreator) ===
+              false
+          ) {
+            return Promise.reject({
+              status: 400,
+              msg: "You cannot change the creator to a user who is not attending the trip.",
+            });
+          }
+        }
+        if (newTripDetails.removePeople) {
+          if (
+            newTripDetails.removePeople.includes(newTripDetails.newCreator) ===
+            true
+          ) {
+            return Promise.reject({
+              status: 400,
+              msg: "You cannot change the creator to a user you are removing.",
+            });
+          }
+        }
+      }
+
       if (newTripDetails.endDate && !newTripDetails.startDate) {
         if (new Date(newTripDetails.endDate) < new Date(trip.startDate)) {
           return Promise.reject({

--- a/api/models/trips.models.js
+++ b/api/models/trips.models.js
@@ -32,7 +32,7 @@ exports.selectTrips = (username) => {
 exports.postTrip = (newTrip) => {
   return Promise.all([
     checkTypes("tripName", newTrip.tripName, "string"),
-    checkUsersExist(newTrip.attending),
+    checkUsersExist("attending", newTrip.attending),
     checkBudget(newTrip.budgetGBP),
     checkCountry(newTrip.country),
     checkTypes("accommodation", newTrip.accommodation, "object"),
@@ -149,6 +149,41 @@ exports.updateTrip = (trip_id, username, newTripDetails) => {
             return Promise.reject({
               status: 400,
               msg: `User '${newTripDetails.addPeople[i]}' is already attending.`,
+            });
+          }
+        }
+      }
+      if (newTripDetails.removePeople) {
+        for (let i = 0; i < newTripDetails.removePeople.length; i++) {
+          if (
+            (currentlyAttending.length === 1 &&
+              !newTripDetails.addPeople &&
+              username === newTripDetails.removePeople[0]) ||
+            (currentlyAttending.length === 1 &&
+              newTripDetails.addPeople &&
+              !newTripDetails.newCreator)
+          ) {
+            return Promise.reject({
+              status: 400,
+              msg: `Your trip must have a creator.`,
+            });
+          }
+          if (
+            currentlyAttending.includes(newTripDetails.removePeople[i]) ===
+            false
+          ) {
+            return Promise.reject({
+              status: 400,
+              msg: `User '${newTripDetails.removePeople[i]}' is not listed as attending this trip.`,
+            });
+          }
+          if (
+            currentlyAttending[0] !== username &&
+            newTripDetails.removePeople[i] !== username
+          ) {
+            return Promise.reject({
+              status: 401,
+              msg: `You are unauthorised to remove user '${newTripDetails.removePeople[i]}' from this trip.`,
             });
           }
         }

--- a/api/models/trips.models.js
+++ b/api/models/trips.models.js
@@ -120,16 +120,28 @@ exports.removeTrip = (trip_id, username) => {
 };
 
 exports.updateTrip = (trip_id, username, newTripDetails) => {
-  const setDetails = buildSetQuery(newTripDetails);
-  const query = {
-    _id: new ObjectId(trip_id),
-  };
   return trips
-    .updateOne(query, setDetails, { upsert: true })
-    .then(() => {
-      return trips.findOne({ _id: new ObjectId(trip_id) });
-    })
+    .findOne({ _id: new ObjectId(trip_id) })
     .then((trip) => {
-      return trip;
+      const currentlyAttending = [...trip.attending];
+      return currentlyAttending;
+    })
+    .then((currentlyAttending) => {
+      const setDetails = buildSetQuery(
+        trip_id,
+        newTripDetails,
+        currentlyAttending
+      );
+      const query = {
+        _id: new ObjectId(trip_id),
+      };
+      return trips
+        .updateOne(query, setDetails, { upsert: true })
+        .then(() => {
+          return trips.findOne({ _id: new ObjectId(trip_id) });
+        })
+        .then((trip) => {
+          return trip;
+        });
     });
 };

--- a/api/models/trips.models.js
+++ b/api/models/trips.models.js
@@ -7,6 +7,7 @@ const {
   checkUsersExist,
   checkBudget,
   checkCountry,
+  buildSetQuery,
 } = require("../utility");
 //TODO further investigation of MongoDB injection attacks
 // TODO look into getting more country information
@@ -115,5 +116,20 @@ exports.removeTrip = (trip_id, username) => {
           msg: "You are unauthorised to delete this trip.",
         });
       }
+    });
+};
+
+exports.updateTrip = (trip_id, username, newTripDetails) => {
+  const setDetails = buildSetQuery(newTripDetails);
+  const query = {
+    _id: new ObjectId(trip_id),
+  };
+  return trips
+    .updateOne(query, setDetails, { upsert: true })
+    .then(() => {
+      return trips.findOne({ _id: new ObjectId(trip_id) });
+    })
+    .then((trip) => {
+      return trip;
     });
 };

--- a/api/models/trips.models.js
+++ b/api/models/trips.models.js
@@ -143,6 +143,16 @@ exports.updateTrip = (trip_id, username, newTripDetails) => {
       return currentlyAttending;
     })
     .then((currentlyAttending) => {
+      if (newTripDetails.addPeople) {
+        for (let i = 0; i < newTripDetails.addPeople.length; i++) {
+          if (currentlyAttending.includes(newTripDetails.addPeople[i])) {
+            return Promise.reject({
+              status: 400,
+              msg: `User '${newTripDetails.addPeople[i]}' is already attending.`,
+            });
+          }
+        }
+      }
       const setDetails = buildSetQuery(
         trip_id,
         newTripDetails,

--- a/api/models/trips.models.js
+++ b/api/models/trips.models.js
@@ -14,6 +14,7 @@ const {
 //TODO further investigation of MongoDB injection attacks
 // TODO look into getting more country information
 // TODO error handling for the latitude and longitude ranges, every key on address object should be string
+// TODO turn the buildSetQuery (utility) function into a promise which takes the current trip and the new details, then we can merge all the promise.reject error handling from the model, the build set query and the validation function together
 const trips = db.collection("trips");
 
 exports.selectTrips = (username) => {

--- a/api/utility.js
+++ b/api/utility.js
@@ -173,10 +173,30 @@ exports.checkFields = (newTripDetails) => {
   }
 };
 
-exports.buildSetQuery = (trip_id, newTripDetails, currentlyAttending) => {
+exports.buildSetQuery = (
+  trip_id,
+  newTripDetails,
+  currentlyAttending,
+  originalDuration,
+  newDuration,
+  days
+) => {
   const set = {};
   const push = {};
   const pull = {};
+
+  console.log(originalDuration, newDuration);
+
+  if (newDuration < originalDuration) {
+    const newDays = [...days];
+    console.log(newDays);
+    for (let i = 0; i < newDays.length; i++) {
+      if (newDays[i].dayNumber > newDuration) {
+        newDays[i].dayNumber = 0;
+      }
+    }
+    set.days = newDays;
+  }
 
   if (newTripDetails.tripName) {
     set.tripName = newTripDetails.tripName;

--- a/api/utility.js
+++ b/api/utility.js
@@ -89,3 +89,31 @@ exports.checkCountry = (country) => {
     });
   });
 };
+
+exports.buildSetQuery = (newTripDetails) => {
+  const set = {};
+  const push = {};
+  if (newTripDetails.tripName) {
+    set.tripName = newTripDetails.tripName;
+  }
+  if (newTripDetails.startDate) {
+    set.startDate = new Date(newTripDetails.startDate);
+  }
+  if (newTripDetails.endDate) {
+    set.endDate = new Date(newTripDetails.endDate);
+  }
+  if (newTripDetails.budgetGBP) {
+    set.budgetGBP = newTripDetails.budgetGBP;
+  }
+  if (newTripDetails.accommodation) {
+    set.accommodation = newTripDetails.accommodation;
+  }
+  if (newTripDetails.addPeople) {
+    push.attending = { $each: newTripDetails.addPeople };
+  }
+
+  return {
+    $set: set,
+    $push: push,
+  };
+};

--- a/api/utility.js
+++ b/api/utility.js
@@ -120,6 +120,9 @@ exports.checkFields = (newTripDetails) => {
             this.checkTypes(field, newTripDetails[field], "string")
           );
         }
+        if (field === "budgetGBP") {
+          validationPromises.push(this.checkBudget(newTripDetails[field]));
+        }
       }
     }
     return Promise.all(validationPromises);

--- a/api/utility.js
+++ b/api/utility.js
@@ -185,11 +185,8 @@ exports.buildSetQuery = (
   const push = {};
   const pull = {};
 
-  console.log(originalDuration, newDuration);
-
   if (newDuration < originalDuration) {
     const newDays = [...days];
-    console.log(newDays);
     for (let i = 0; i < newDays.length; i++) {
       if (newDays[i].dayNumber > newDuration) {
         newDays[i].dayNumber = 0;

--- a/api/utility.js
+++ b/api/utility.js
@@ -24,31 +24,34 @@ exports.checkTypes = (keyName, value, type) => {
   return Promise.resolve();
 };
 
-exports.checkDates = (startDate, endDate) => {
-  if (startDate === undefined) {
+exports.checkDate = (dateName, date) => {
+  if (date === undefined) {
     return Promise.reject({
       status: 400,
-      msg: `startDate has not been provided.`,
-    });
-  } else if (endDate === undefined) {
-    return Promise.reject({
-      status: 400,
-      msg: `endDate has not been provided.`,
+      msg: `${dateName} has not been provided.`,
     });
   }
-  if (new Date(startDate).toString() === "Invalid Date") {
+  if (
+    new Date(date).toString() === "Invalid Date" ||
+    typeof date === "number"
+  ) {
     return Promise.reject({
       status: 400,
-      msg: `startDate is not type 'date'.`,
+      msg: `${dateName} is not type 'date'.`,
     });
-  } else if (new Date(startDate) < Date.now()) {
+  }
+
+  if (dateName === "startDate" && new Date(date) < Date.now()) {
     return Promise.reject({
       status: 400,
-      msg: `startDate cannot be in the past.`,
+      msg: `${dateName} cannot be in the past.`,
     });
-  } else if (new Date(endDate).toString() === "Invalid Date") {
-    return Promise.reject({ status: 400, msg: `endDate is not type 'date'.` });
-  } else if (new Date(endDate) < new Date(startDate)) {
+  }
+  return Promise.resolve();
+};
+
+exports.checkDateRelationship = (startDate, endDate) => {
+  if (new Date(endDate) < new Date(startDate)) {
     return Promise.reject({
       status: 400,
       msg: `endDate cannot be before startDate.`,
@@ -156,6 +159,10 @@ exports.checkFields = (newTripDetails) => {
             this.checkUsersExist(field, newTripDetails[field])
           );
         }
+
+        if (field === "startDate" || field === "endDate") {
+          validationPromises.push(this.checkDate(field, newTripDetails[field]));
+        }
       }
     }
     return Promise.all(validationPromises);
@@ -163,6 +170,7 @@ exports.checkFields = (newTripDetails) => {
 };
 
 exports.buildSetQuery = (trip_id, newTripDetails, currentlyAttending) => {
+  console.log("here");
   const set = {};
   const push = {};
   const pull = {};

--- a/api/utility.js
+++ b/api/utility.js
@@ -10,6 +10,11 @@ exports.checkTypes = (keyName, value, type) => {
   }
   if (type === "array" && Array.isArray(value) === true) {
     return Promise.resolve();
+  } else if (type === "object" && Array.isArray(value) === true) {
+    return Promise.reject({
+      status: 400,
+      msg: `${keyName} is not type '${type}'.`,
+    });
   } else if (typeof value !== type) {
     return Promise.reject({
       status: 400,
@@ -122,6 +127,27 @@ exports.checkFields = (newTripDetails) => {
         }
         if (field === "budgetGBP") {
           validationPromises.push(this.checkBudget(newTripDetails[field]));
+        }
+        if (field === "accommodation") {
+          validationPromises.push(
+            this.checkTypes(field, newTripDetails[field], "object"),
+            this.checkTypes(
+              "accommodationName",
+              newTripDetails[field].accommodationName,
+              "string"
+            ),
+            this.checkTypes(
+              "longitude",
+              newTripDetails[field].longitude,
+              "number"
+            ),
+            this.checkTypes(
+              "latitude",
+              newTripDetails[field].latitude,
+              "number"
+            ),
+            this.checkTypes("address", newTripDetails[field].address, "object")
+          );
         }
       }
     }

--- a/api/utility.js
+++ b/api/utility.js
@@ -90,9 +90,10 @@ exports.checkCountry = (country) => {
   });
 };
 
-exports.buildSetQuery = (newTripDetails) => {
+exports.buildSetQuery = (trip_id, newTripDetails, currentlyAttending) => {
   const set = {};
   const push = {};
+  const pull = {};
   if (newTripDetails.tripName) {
     set.tripName = newTripDetails.tripName;
   }
@@ -108,12 +109,36 @@ exports.buildSetQuery = (newTripDetails) => {
   if (newTripDetails.accommodation) {
     set.accommodation = newTripDetails.accommodation;
   }
-  if (newTripDetails.addPeople) {
+
+  if (newTripDetails.addPeople && newTripDetails.newCreator) {
+    const creatorRemoved = [...currentlyAttending, ...newTripDetails.addPeople];
+    creatorRemoved.splice(
+      creatorRemoved.indexOf(`${newTripDetails.newCreator}`),
+      1
+    );
+    set.attending = [newTripDetails.newCreator, ...creatorRemoved];
+  }
+
+  if (newTripDetails.addPeople && !newTripDetails.newCreator) {
     push.attending = { $each: newTripDetails.addPeople };
+  }
+
+  if (newTripDetails.newCreator && !newTripDetails.addPeople) {
+    const creatorRemoved = [...currentlyAttending];
+    creatorRemoved.splice(
+      creatorRemoved.indexOf(`${newTripDetails.newCreator}`),
+      1
+    );
+    set.attending = [newTripDetails.newCreator, ...creatorRemoved];
+  }
+
+  if (newTripDetails.removePeople) {
+    pull.attending = { $in: newTripDetails.removePeople };
   }
 
   return {
     $set: set,
     $push: push,
+    $pull: pull,
   };
 };

--- a/api/utility.js
+++ b/api/utility.js
@@ -90,10 +90,30 @@ exports.checkCountry = (country) => {
   });
 };
 
+exports.checkFields = (object, fieldsArr) => {
+  if (Object.keys(object).length === 0) {
+    return Promise.reject({
+      status: 400,
+      msg: "Please provide details of the updates to be made.",
+    });
+  } else {
+    for (const prop in object) {
+      if (fieldsArr.indexOf(prop) === -1) {
+        return Promise.reject({
+          status: 400,
+          msg: `Cannot update field '${prop}'.`,
+        });
+      }
+    }
+    return Promise.resolve();
+  }
+};
+
 exports.buildSetQuery = (trip_id, newTripDetails, currentlyAttending) => {
   const set = {};
   const push = {};
   const pull = {};
+
   if (newTripDetails.tripName) {
     set.tripName = newTripDetails.tripName;
   }

--- a/api/utility.js
+++ b/api/utility.js
@@ -95,6 +95,23 @@ exports.checkCountry = (country) => {
   });
 };
 
+exports.checkPeopleArray = (fieldName, peopleArray) => {
+  return this.checkTypes(fieldName, peopleArray, "array")
+    .then(() => {
+      if (peopleArray.length === 0) {
+        return Promise.reject({
+          status: 400,
+          msg: `${fieldName} requires one or more usernames.`,
+        });
+      }
+    })
+    .then(() => {
+      for (let i = 0; i < peopleArray.length; i++) {
+        return selectUsername(peopleArray[i]);
+      }
+    });
+};
+
 exports.checkFields = (newTripDetails) => {
   const allowedFields = [
     "tripName",
@@ -147,6 +164,11 @@ exports.checkFields = (newTripDetails) => {
               "number"
             ),
             this.checkTypes("address", newTripDetails[field].address, "object")
+          );
+        }
+        if (field === "addPeople") {
+          validationPromises.push(
+            this.checkPeopleArray(field, newTripDetails[field])
           );
         }
       }

--- a/api/utility.js
+++ b/api/utility.js
@@ -90,22 +90,39 @@ exports.checkCountry = (country) => {
   });
 };
 
-exports.checkFields = (object, fieldsArr) => {
-  if (Object.keys(object).length === 0) {
+exports.checkFields = (newTripDetails) => {
+  const allowedFields = [
+    "tripName",
+    "startDate",
+    "endDate",
+    "budgetGBP",
+    "accommodation",
+    "addPeople",
+    "removePeople",
+    "newCreator",
+  ];
+  const validationPromises = [];
+  if (Object.keys(newTripDetails).length === 0) {
     return Promise.reject({
       status: 400,
       msg: "Please provide details of the updates to be made.",
     });
   } else {
-    for (const prop in object) {
-      if (fieldsArr.indexOf(prop) === -1) {
+    for (const field in newTripDetails) {
+      if (allowedFields.indexOf(field) === -1) {
         return Promise.reject({
           status: 400,
-          msg: `Cannot update field '${prop}'.`,
+          msg: `Cannot update field '${field}'.`,
         });
+      } else {
+        if (field === "tripName") {
+          validationPromises.push(
+            this.checkTypes(field, newTripDetails[field], "string")
+          );
+        }
       }
     }
-    return Promise.resolve();
+    return Promise.all(validationPromises);
   }
 };
 

--- a/api/utility.js
+++ b/api/utility.js
@@ -163,6 +163,10 @@ exports.checkFields = (newTripDetails) => {
         if (field === "startDate" || field === "endDate") {
           validationPromises.push(this.checkDate(field, newTripDetails[field]));
         }
+
+        if (field === "newCreator") {
+          validationPromises.push(selectUsername(newTripDetails[field]));
+        }
       }
     }
     return Promise.all(validationPromises);
@@ -170,7 +174,6 @@ exports.checkFields = (newTripDetails) => {
 };
 
 exports.buildSetQuery = (trip_id, newTripDetails, currentlyAttending) => {
-  console.log("here");
   const set = {};
   const push = {};
   const pull = {};

--- a/db/data/trips.js
+++ b/db/data/trips.js
@@ -17,7 +17,7 @@ module.exports = [
     days: [
       {
         _id: ObjectId(),
-        dayNumber:1,
+        dayNumber: 1,
         activities: [
           {
             _id: ObjectId(),
@@ -39,7 +39,7 @@ module.exports = [
       },
       {
         _id: ObjectId(),
-        dayNumber:2,
+        dayNumber: 2,
         activities: [
           {
             _id: ObjectId(),
@@ -68,8 +68,8 @@ module.exports = [
     },
     days: [
       {
-        _id:ObjectId(),
-        dayNumber:1,
+        _id: ObjectId(),
+        dayNumber: 1,
         activities: [
           {
             _id: ObjectId(),
@@ -82,8 +82,8 @@ module.exports = [
         ],
       },
       {
-        _id:ObjectId(),
-        dayNumber:2,
+        _id: ObjectId(),
+        dayNumber: 2,
         activities: [
           {
             _id: ObjectId(),
@@ -107,8 +107,8 @@ module.exports = [
         ],
       },
       {
-        _id:ObjectId(),
-        dayNumber:3,
+        _id: ObjectId(),
+        dayNumber: 3,
         activities: [
           {
             _id: ObjectId(),
@@ -146,8 +146,8 @@ module.exports = [
     },
     days: [
       {
-        _id:ObjectId(),
-        dayNumber:1,
+        _id: ObjectId(),
+        dayNumber: 1,
         activities: [
           {
             _id: ObjectId(),
@@ -185,8 +185,8 @@ module.exports = [
         ],
       },
       {
-        _id:ObjectId(),
-        dayNumber:2,
+        _id: ObjectId(),
+        dayNumber: 2,
         activities: [
           {
             _id: ObjectId(),
@@ -209,8 +209,8 @@ module.exports = [
         ],
       },
       {
-        _id:ObjectId(),
-        dayNumber:3,
+        _id: ObjectId(),
+        dayNumber: 3,
         activities: [
           {
             _id: ObjectId(),
@@ -261,8 +261,8 @@ module.exports = [
     },
     days: [
       {
-        _id:ObjectId(),
-        dayNumber:1,
+        _id: ObjectId(),
+        dayNumber: 1,
         activities: [
           {
             _id: ObjectId(),


### PR DESCRIPTION
See notes on Trello for errors covered and what this endpoint allows.
Very aware that this needs some refactoring in the future: one idea would be to turn the buildSetQuery (utility) function into a promise which takes the current trip and the new details, then we can merge all the promise.reject error handling from the model, the build set query and the validation (utility) function together.